### PR TITLE
fix(ENTESB-17594): Add Kafka header auto deserialize

### DIFF
--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       YAKS_IMAGE_NAME: "docker.io/citrusframework/yaks"
-      YAKS_VERSION: "0.7.0"
+      YAKS_VERSION: "0.8.0"
       YAKS_RUN_OPTIONS: "--timeout=15m"
       KUBECTL_WAIT_TIMEOUT: "180s"
     steps:
@@ -98,3 +98,8 @@ jobs:
           yaks run test/ftp/source $YAKS_RUN_OPTIONS
           yaks run test/kafka $YAKS_RUN_OPTIONS
           yaks run test/postgresql $YAKS_RUN_OPTIONS
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: dumps
+          path: /tmp/dumps/*.log

--- a/kafka-source.kamelet.yaml
+++ b/kafka-source.kamelet.yaml
@@ -36,12 +36,12 @@ spec:
         default: SASL_SSL
       saslMechanism:
         title: SASL Mechanism
-        description: The Simple Authentication and Security Layer (SASL) Mechanism used. 
+        description: The Simple Authentication and Security Layer (SASL) Mechanism used.
         type: string
         default: PLAIN
       user:
         title: Username
-        description: Username to authenticate to Kafka 
+        description: Username to authenticate to Kafka
         type: string
       password:
         title: Password
@@ -74,7 +74,16 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
+      deserializeHeaders:
+        title: Automatically Deserialize Headers
+        description: When enabled the Kamelet source will deserialize all message headers to String representation.
+        type: boolean
+        default: false
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
+    - "github:christophd.kamelet-catalog:camel-kamelets-utils:jitpack-SNAPSHOT"
+    - "camel:core"
     - "camel:kafka"
     - "camel:kamelet"
   flow:
@@ -90,4 +99,12 @@ spec:
         pollOnError: "{{pollOnError}}"
         autoOffsetReset: "{{autoOffsetReset}}"
       steps:
+      - set-property:
+          name: deserializeHeaders
+          constant: "{{deserializeHeaders}}"
+      - choice:
+          when:
+            - simple: "${exchangeProperty.deserializeHeaders} == 'true'"
+              steps:
+                - bean: "org.apache.camel.kamelets.utils.serialization.kafka.KafkaHeaderDeserializer"
       - to: "kamelet:sink"

--- a/library/camel-kamelets-bom/pom.xml
+++ b/library/camel-kamelets-bom/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.kamelets</groupId>
         <artifactId>camel-kamelets-parent</artifactId>
-        <version>main-SNAPSHOT</version>
+        <version>master-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/kafka-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/kafka-source.kamelet.yaml
@@ -36,12 +36,12 @@ spec:
         default: SASL_SSL
       saslMechanism:
         title: SASL Mechanism
-        description: The Simple Authentication and Security Layer (SASL) Mechanism used. 
+        description: The Simple Authentication and Security Layer (SASL) Mechanism used.
         type: string
         default: PLAIN
       user:
         title: Username
-        description: Username to authenticate to Kafka 
+        description: Username to authenticate to Kafka
         type: string
       password:
         title: Password
@@ -74,7 +74,16 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
+      deserializeHeaders:
+        title: Automatically Deserialize Headers
+        description: When enabled the Kamelet source will deserialize all message headers to String representation.
+        type: boolean
+        default: false
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
+    - "github:christophd.kamelet-catalog:camel-kamelets-utils:jitpack-SNAPSHOT"
+    - "camel:core"
     - "camel:kafka"
     - "camel:kamelet"
   flow:
@@ -90,4 +99,12 @@ spec:
         pollOnError: "{{pollOnError}}"
         autoOffsetReset: "{{autoOffsetReset}}"
       steps:
+      - set-property:
+          name: deserializeHeaders
+          constant: "{{deserializeHeaders}}"
+      - choice:
+          when:
+            - simple: "${exchangeProperty.deserializeHeaders} == 'true'"
+              steps:
+                - bean: "org.apache.camel.kamelets.utils.serialization.kafka.KafkaHeaderDeserializer"
       - to: "kamelet:sink"

--- a/library/camel-kamelets-utils/pom.xml
+++ b/library/camel-kamelets-utils/pom.xml
@@ -72,6 +72,21 @@
             <artifactId>camel-kafka</artifactId>
         </dependency>
 
+        <!-- Test scoped dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+            <version>${junit.jupiter.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+            <version>${junit.jupiter.version}</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/library/camel-kamelets-utils/src/main/java/org/apache/camel/kamelets/utils/serialization/kafka/KafkaHeaderDeserializer.java
+++ b/library/camel-kamelets-utils/src/main/java/org/apache/camel/kamelets/utils/serialization/kafka/KafkaHeaderDeserializer.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kamelets.utils.serialization.kafka;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.TypeConverter;
+import org.apache.camel.support.SimpleTypeConverter;
+
+/**
+ * Header deserializer used in Kafka source Kamelet. Automatically converts all message headers to String.
+ * Uses given type converter implementation set on the Camel context to convert values. If no type converter is set
+ * the deserializer uses its own fallback conversion implementation.
+ */
+public class KafkaHeaderDeserializer implements Processor {
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        Map<String, Object> headers = exchange.getMessage().getHeaders();
+
+        TypeConverter typeConverter = exchange.getContext().getTypeConverter();
+        if (typeConverter == null) {
+            typeConverter = new SimpleTypeConverter(true, this::convert);
+        }
+
+        for (Map.Entry<String, Object> header : headers.entrySet()) {
+            header.setValue(typeConverter.convertTo(String.class, header.getValue()));
+        }
+    }
+
+    /**
+     * Fallback conversion strategy supporting null values, String and byte[]. Converts headers to respective
+     * String representation or null.
+     * @param type target type, always String in this case.
+     * @param exchange the exchange containing all headers to convert.
+     * @param value the current value to convert.
+     * @return String representation of given value or null if value itself is null.
+     */
+    private Object convert(Class<?> type, Exchange exchange, Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        if (value instanceof String) {
+            return value;
+        }
+
+        if (value instanceof byte[]) {
+            return new String((byte[]) value, StandardCharsets.UTF_8);
+        }
+
+        return value.toString();
+    }
+}

--- a/library/camel-kamelets-utils/src/test/java/org/apache/camel/kamelets/utils/serialization/kafka/KafkaHeaderDeserializerTest.java
+++ b/library/camel-kamelets-utils/src/test/java/org/apache/camel/kamelets/utils/serialization/kafka/KafkaHeaderDeserializerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kamelets.utils.serialization.kafka;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.apache.camel.support.SimpleTypeConverter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+class KafkaHeaderDeserializerTest {
+
+    private DefaultCamelContext camelContext;
+
+    private final KafkaHeaderDeserializer processor = new KafkaHeaderDeserializer();
+
+    @BeforeEach
+    void setup() {
+        this.camelContext = new DefaultCamelContext();
+    }
+
+    @Test
+    void shouldDeserializeHeaders() throws Exception {
+        Exchange exchange = new DefaultExchange(camelContext);
+
+        exchange.getMessage().setHeader("foo", "bar");
+        exchange.getMessage().setHeader("fooBytes", "barBytes".getBytes(StandardCharsets.UTF_8));
+        exchange.getMessage().setHeader("fooNull", null);
+        exchange.getMessage().setHeader("number", 1L);
+
+        processor.process(exchange);
+
+        Assertions.assertTrue(exchange.getMessage().hasHeaders());
+        Assertions.assertEquals("bar", exchange.getMessage().getHeader("foo"));
+        Assertions.assertEquals("barBytes", exchange.getMessage().getHeader("fooBytes"));
+        Assertions.assertTrue(exchange.getMessage().getHeaders().containsKey("fooNull"));
+        Assertions.assertNull(exchange.getMessage().getHeader("fooNull"));
+        Assertions.assertEquals("1", exchange.getMessage().getHeader("number"));
+    }
+
+    @Test
+    void shouldDeserializeHeadersViaTypeConverter() throws Exception {
+        camelContext.setTypeConverter(new SimpleTypeConverter(true, (type, exchange, value) -> "converted"));
+
+        Exchange exchange = new DefaultExchange(camelContext);
+
+        exchange.getMessage().setHeader("foo", "bar");
+        exchange.getMessage().setHeader("fooBytes", "barBytes".getBytes(StandardCharsets.UTF_8));
+        exchange.getMessage().setHeader("fooNull", null);
+
+        processor.process(exchange);
+
+        Assertions.assertTrue(exchange.getMessage().hasHeaders());
+        Assertions.assertEquals("converted", exchange.getMessage().getHeader("foo"));
+        Assertions.assertEquals("converted", exchange.getMessage().getHeader("fooBytes"));
+        Assertions.assertEquals("converted", exchange.getMessage().getHeader("fooNull"));
+    }
+}

--- a/test/kafka/kafka-sink.feature
+++ b/test/kafka/kafka-sink.feature
@@ -11,8 +11,6 @@ Feature: Kafka Kamelet sink
       | message                   | Camel K rocks! |
     Given Kafka topic: ${topic}
     Given Kafka topic partition: 0
-    Given Kafka connection
-      | url         | ${bootstrap.server.host}.${YAKS_NAMESPACE}:${bootstrap.server.port} |
 
   Scenario: Create Kamelet binding
     Given Camel-K resource polling configuration
@@ -22,6 +20,8 @@ Feature: Kafka Kamelet sink
     Then Camel-K integration kafka-sink-test should be running
 
   Scenario: Receive message on Kafka topic and verify sink output
+    Given Kafka connection
+      | url         | ${bootstrap.server.host}.${YAKS_NAMESPACE}:${bootstrap.server.port} |
     Then receive Kafka message with body: ${message}
 
   Scenario: Remove resources

--- a/test/kafka/kafka-source-test.yaml
+++ b/test/kafka/kafka-source-test.yaml
@@ -14,6 +14,7 @@ spec:
       password: ${password}
       topic: ${topic}
       securityProtocol: ${securityProtocol}
+      deserializeHeaders: ${deserializeHeaders}
   sink:
     uri: http://kafka-to-http-service.${YAKS_NAMESPACE}/result
 

--- a/test/kafka/kafka-source.feature
+++ b/test/kafka/kafka-source.feature
@@ -7,13 +7,12 @@ Feature: Kafka Kamelet source
       | bootstrap.server.host     | my-cluster-kafka-bootstrap |
       | bootstrap.server.port     | 9092 |
       | securityProtocol          | PLAINTEXT |
+      | deserializeHeaders        | true |
       | topic                     | my-topic |
       | source                    | Kafka Kamelet source |
       | message                   | Camel K rocks! |
     Given Kafka topic: ${topic}
     Given Kafka topic partition: 0
-    Given Kafka connection
-      | url         | ${bootstrap.server.host}.${YAKS_NAMESPACE}:${bootstrap.server.port} |
     Given HTTP server timeout is 15000 ms
     Given HTTP server "kafka-to-http-service"
 
@@ -29,10 +28,12 @@ Feature: Kafka Kamelet source
     And Camel-K integration kafka-source-test should print Resetting offset for partition ${topic}-0
 
   Scenario: Send message to Kafka topic and verify sink output
+    Given Kafka connection
+      | url         | ${bootstrap.server.host}.${YAKS_NAMESPACE}:${bootstrap.server.port} |
     When send Kafka message with body and headers: ${message}
       | event-source | ${source} |
     Then expect HTTP request body: ${message}
-    Then expect HTTP request header: event-source="@notNull()@"
+    Then expect HTTP request header: event-source="${source}"
     And receive POST /result
     And send HTTP 200 OK
 

--- a/test/kafka/yaks-config.yaml
+++ b/test/kafka/yaks-config.yaml
@@ -31,3 +31,17 @@ pre:
   - name: Install Kafka
     if: env:CI=true
     script: install.sh
+  - name: Prepare Kamelets
+    if: env:CI=true
+    run: |
+      kubectl delete kamelet kafka-source -n $YAKS_NAMESPACE
+      kubectl delete kamelet kafka-sink -n $YAKS_NAMESPACE
+      kubectl apply -f ../../kafka-source.kamelet.yaml -n $YAKS_NAMESPACE
+      kubectl apply -f ../../kafka-sink.kamelet.yaml -n $YAKS_NAMESPACE
+post:
+  - name: Dump
+    if: env:CI=true
+    run: |
+      kamel dump -n $YAKS_NAMESPACE $(basename `pwd`)-dump.log
+      mkdir -p /tmp/dumps
+      cp *-dump.log /tmp/dumps


### PR DESCRIPTION
- Add option to enable automatic header deserialize
- When enabled Kafka source will automatically deserialize message headers to String
- Update YAKS test to use header deserialization
- Use YAKS v0.8.0